### PR TITLE
[R/0.1.0/#55] Replace pickle with msgpath for exif related functions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
-include README.rst LICENSE AUTHORS HISTORY.rst
+include README.rst LICENSE AUTHORS
 include *.dist
 include requirements.txt
 
+graft docs
 graft scripts
 graft tests

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,6 @@ Developed Python version: Python 3.6. A project of `ViiSiX <https://viisix.space
 
 .. image:: https://travis-ci.org/ViiSiX/ImageButler.svg?branch=R%2F0.1
     :target: https://travis-ci.org/ViiSiX/ImageButler
-.. image:: https://api.codacy.com/project/badge/Grade/d5c733a686d74f61af3ab09d7c85d288
-    :target: https://www.codacy.com/app/ViiSiX/ImageButler?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ViiSiX/ImageButler&amp;utm_campaign=Badge_Grade
 
 Installation
 ------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,8 +22,6 @@ Build's statuses
 
 .. image:: https://travis-ci.org/ViiSiX/ImageButler.svg?branch=R%2F0.1
     :target: https://travis-ci.org/ViiSiX/ImageButler
-.. image:: https://api.codacy.com/project/badge/Grade/d5c733a686d74f61af3ab09d7c85d288
-    :target: https://www.codacy.com/app/ViiSiX/ImageButler?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ViiSiX/ImageButler&amp;utm_campaign=Badge_Grade
 
 User's guide
 ============

--- a/imagebutler/apis/apis.py
+++ b/imagebutler/apis/apis.py
@@ -1,7 +1,7 @@
 """Import libraries and some predefined variables."""
 
 from flask import Blueprint
-from flask_restful import Api, Resource, reqparse
+from flask_restful import Api
 from ..imagebutler import config
 
 

--- a/imagebutler/apis/image.py
+++ b/imagebutler/apis/image.py
@@ -4,7 +4,7 @@ is username and password. Later we can use something like JWT or PEM file.
 """
 
 from werkzeug.datastructures import FileStorage
-from .apis import Resource, reqparse
+from flask_restful import Resource, reqparse
 from ..imagebutler import rdb
 from ..models import db, ImageModel, UserModel
 from ..utils import user_identity_check

--- a/imagebutler/apis/images.py
+++ b/imagebutler/apis/images.py
@@ -1,7 +1,8 @@
 """APIs used for more than one image at the same time."""
 
 from babel.dates import format_datetime
-from .apis import Resource, reqparse, config
+from flask_restful import Resource, reqparse
+from .apis import config
 from ..models import ImageModel, UserModel
 from ..utils import user_identity_check
 

--- a/imagebutler/apis/ping.py
+++ b/imagebutler/apis/ping.py
@@ -1,5 +1,6 @@
 """Just a prototype for REST-ful."""
-from .apis import Resource
+
+from flask_restful import Resource
 
 
 class Ping(Resource):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ apipkg==1.4
 argh==0.26.2
 astroid==1.5.3
 Babel==2.5.1
+bandit==1.4.0
 certifi==2017.11.5
 chardet==3.0.4
 click==6.7
@@ -18,6 +19,8 @@ Flask-Migrate==2.1.1
 Flask-Redislite==0.1.1
 Flask-RESTful==0.3.6
 Flask-SQLAlchemy==2.3.2
+gitdb2==2.0.3
+GitPython==2.1.8
 idna==2.6
 imagesize==0.7.1
 isort==4.2.15
@@ -28,8 +31,10 @@ livereload==2.5.1
 Mako==1.0.7
 MarkupSafe==1.0
 mccabe==0.6.1
+msgpack-python==0.4.8
 olefile==0.44
 pathtools==0.1.2
+pbr==3.1.1
 pep8==1.7.1
 piexif==1.0.13
 Pillow==4.3.0
@@ -57,11 +62,13 @@ redislite==3.2.311
 requests==2.18.4
 rq==0.9.1
 six==1.11.0
+smmap2==2.0.3
 snowballstemmer==1.2.1
 Sphinx==1.6.5
 sphinx-autobuild==0.7.1
 sphinxcontrib-websupport==1.0.1
 SQLAlchemy==1.1.14
+stevedore==1.28.0
 tornado==4.5.2
 tox==2.9.1
 urllib3==1.22

--- a/scripts/test
+++ b/scripts/test
@@ -10,15 +10,21 @@ py.test "$BASEDIR"/tests \
     --cov "$BASEDIR"/imagebutler \
     --cov-report term-missing
 
+if [ $? -gt 0 ]; then exit 1; fi
+
 echo "================"
 echo "PEP8 violations:"
 echo "================"
 pycodestyle --first "$BASEDIR"/imagebutler
 echo "================"
-echo "End of PEP8./."
+echo "End of PEP8./."; echo ""
+echo "================"
+echo "Bandit check:"
+echo "================"
+bandit -r "$BASEDIR"/imagebutler
 echo "================"
 echo "Document link check:"
 echo "================"
 cd docs && make linkcheck
 echo "================"
-echo "End of Document link check./."
+echo "End of Document link check./."; echo ""

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         'pycrypto',
         'Pillow',
         'progressbar2',
-        'piexif'
+        'piexif',
+        'msgpack-python'
     ],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
Fixes #55 

**Proposed Changes**
 - Replace `pickle` with `msgpath` for exif related functions
 - Add new test to ensure consistency of exif
 - Include `docs` to pypi packages
 - Update `requirements.txt`
 - Remove codacy
